### PR TITLE
PHP 7.x compatibility

### DIFF
--- a/packages/collections/pub/eadlist.php
+++ b/packages/collections/pub/eadlist.php
@@ -36,7 +36,7 @@ while ($row = $result->fetchRow())
                {
                   ?>
          <a href='?p=collections/ead&amp;id=<?php echo($objCollection['ID']); ?>&amp;templateset=ead&amp;disabletheme=1&amp;output=<?php echo(encode(formatFileName($objCollection['SortTitle']),ENCODE_HTML)); ?>'><?php echo(encode(trim($objCollection['Title']),ENCODE_HTML)); ?></a><br/>
-                  <?
+                  <?php
                }
             }
             else

--- a/packages/core/lib/archon.inc.php
+++ b/packages/core/lib/archon.inc.php
@@ -2673,7 +2673,13 @@ abstract class Core_Archon
          }
 
          //$result = call_user_func(array($MixinClass, initialize));
-         eval("\$result = {$MixinClass}::initialize();");
+         $myMixinClass = "___{$MixinClass}___";
+         if (!class_exists($myMixinClass)) {
+            eval("class $myMixinClass extends $MixinClass {}");
+         }
+         $mixin = new $myMixinClass;
+         $closure = (new ReflectionMethod($myMixinClass, 'initialize'))->getClosure($mixin);
+         $result = call_user_func($closure->bindTo($this));
       }
    }
    

--- a/packages/core/lib/archonobject.inc.php
+++ b/packages/core/lib/archonobject.inc.php
@@ -10,20 +10,19 @@ abstract class ArchonObject
       $args = func_get_args();
       $MixinClass = prev($methodInfo->Classes);
 
-      $arrStrArgs = array();
-
-      for($i = 0; $i < count($args); $i++)
-      {
-         $arrStrArgs[] = "\$args[{$i}]";
-      }
-
       // Simulate mixing after.
       if($_ARCHON->Mixins[get_class($this)]->Methods[$method]->Parameters[$MixinClass]->MixOrder == MIX_AFTER)
       {
          $prevresult = call_user_func_array(array($this, 'callOverridden'), $args);
       }
 
-      eval("\$result = {$MixinClass}::{$method}(" . implode(',', $arrStrArgs) . ");");
+      $myMixinClass = "___{$MixinClass}___";
+      if (!class_exists($myMixinClass)) {
+         eval("class $myMixinClass extends $MixinClass {}");
+      }
+      $mixin = new $myMixinClass;
+      $closure = (new ReflectionMethod($myMixinClass, $method))->getClosure($mixin);
+      $result = call_user_func_array($closure->bindTo($this), $args);
 
       // Simulate mixing before.
       if($_ARCHON->Mixins[get_class($this)]->Methods[$method]->Parameters[$MixinClass]->MixOrder == MIX_BEFORE)
@@ -234,21 +233,20 @@ abstract class ArchonObject
          $_ARCHON->Callstack[] = $stackmember;
          $MixinClass = end(end($_ARCHON->Callstack)->Classes);
 
-         $arrStrArgs = array();
-
-         for($i = 0; $i < count($args); $i++)
-         {
-            $arrStrArgs[] = "\$args[{$i}]";
-         }
-
          // Simulate mixing after.
          if($_ARCHON->Mixins[get_class($this)]->Methods[$method]->Parameters[$MixinClass]->MixOrder == MIX_AFTER)
          {
             $prevresult = call_user_func_array(array($this, 'callOverridden'), $args);
          }
 
-         eval("\$result = {$MixinClass}::{$method}(" . implode(',', $arrStrArgs) . ");");
          //$result = call_user_func_array(array(($MixinClass) $this, $method), $args);
+	 $myMixinClass = "___{$MixinClass}___";
+	 if (!class_exists($myMixinClass)) {
+            eval("class $myMixinClass extends $MixinClass {}");
+         }
+         $mixin = new $myMixinClass;
+         $closure = (new ReflectionMethod($myMixinClass, $method))->getClosure($mixin);
+         $result = call_user_func_array($closure->bindTo($this), $args);
 
          // Simulate mixing before.
          if($_ARCHON->Mixins[get_class($this)]->Methods[$method]->Parameters[$MixinClass]->MixOrder == MIX_BEFORE)

--- a/packages/core/lib/querylog.inc.php
+++ b/packages/core/lib/querylog.inc.php
@@ -5,7 +5,7 @@ abstract class Core_QueryLog
     {
         $this->QueryCount++;
 
-        if($OutputQueries)
+        if($this->OutputQueries)
         {
             echo("\n\n$Message\n\n");
         }


### PR DESCRIPTION
We are in the process of adopting Archon at Hekman Library, Calvin College.  After getting it up an running on a PHP 5.6 test server, we then ran into some compatibility issues with PHP 7 on our production server.

The contents of this pullrequest got us to a working state.  There may be more changes lurking in areas of the code we haven't exercised (similar to the small tag fix in the EAD export, included here), but we are now able to browse, search, and do DB imports successfully on our production server.

See the commit comments for much more detail on these changes, and why they are needed.